### PR TITLE
Create sub-tasks for linting rules

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -17,19 +17,6 @@ module.exports = function(grunt) {
       }
     },
     jshint: {
-      files: [
-        'Gruntfile.js',
-        'src/scripts/*.js',
-        'src/scripts/entities/*.js',
-        'src/scripts/apps/bills/*.js',
-        'src/scripts/apps/bills/show/*.js',
-        'src/scripts/apps/members/*.js',
-        'src/scripts/apps/members/list/*.js',
-        'src/scripts/apps/members/show/*.js',
-        'src/scripts/apps/watched_bills/*.js',
-        'src/scripts/apps/watched_bills/list/*.js',
-        'src/scripts/apps/watched_bills/show/*.js'
-      ],
       options: {
         browser: true,
         curly: true,
@@ -41,10 +28,36 @@ module.exports = function(grunt) {
         strict: true,
         trailing: true,
         smarttabs: true,
-        indent: 2,
-        globals: {
-          JQuery: true,
-          $: true
+        indent: 2
+      },
+      src: {
+        options: {
+          globals: {
+            JQuery: true,
+            $: true
+          }
+        },
+        files: {
+          src: [
+            'src/scripts/*.js',
+            'src/scripts/entities/*.js',
+            'src/scripts/apps/bills/*.js',
+            'src/scripts/apps/bills/show/*.js',
+            'src/scripts/apps/members/*.js',
+            'src/scripts/apps/members/list/*.js',
+            'src/scripts/apps/members/show/*.js',
+            'src/scripts/apps/watched_bills/*.js',
+            'src/scripts/apps/watched_bills/list/*.js',
+            'src/scripts/apps/watched_bills/show/*.js'
+          ]
+        }
+      },
+      build: {
+        options: {
+          node: true
+        },
+        files: {
+          src: ['Gruntfile.js']
         }
       }
     },


### PR DESCRIPTION
The "jshint" task currently fails, but this structure allows for more
fine-grained control over linting configuration.
